### PR TITLE
fixed time issue with params in get_guid() function

### DIFF
--- a/index.py
+++ b/index.py
@@ -145,7 +145,8 @@ def get_guid():
     }
     
     params = (
-        ('1537511137854', ''),
+        # Gets the current time since epoch of 1901, 1, 1
+	    (time.time() * 1000, ''),
     )
     
     response = session.post('https://'+url+'/Default.asmx/GetUserInfo', headers=headers, params=params)


### PR DESCRIPTION
the time in milliseconds was hardcoded in the params on line 147-150, this means that it would of failed once the time changes